### PR TITLE
Ignore ruby version and gemset files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+.ruby-version
+.ruby-gemset
+


### PR DESCRIPTION
Some developers (like me!) want to use RVM (or rbenv) to manage their
Rubies and gems while hacking on this library, but there's no reason to
enforce any one particular version of Ruby since this library would
ideally be portable to multiple versions of Ruby.